### PR TITLE
Add todo relation to user logged in

### DIFF
--- a/src/backend/controllers/__test__/allTodos.json
+++ b/src/backend/controllers/__test__/allTodos.json
@@ -2,6 +2,7 @@
   {
     "content": "Test",
     "done": false,
+    "userId": "5a9b1b9e3d1a866534f516e3",
     "createdAt": "2022-10-10T00:00:00.000Z",
     "completedAt": "2022-10-10T00:00:00.000Z"
   }

--- a/src/backend/controllers/__test__/newTodo.json
+++ b/src/backend/controllers/__test__/newTodo.json
@@ -2,6 +2,7 @@
   "id": "5a9b1b9e3d1a866534f516e4",
   "content": "This is a new todo",
   "done": false,
+  "userId": "5a9b1b9e3d1a866534f516e3",
   "createdAt": "2022-10-20T05:11:36.860Z",
   "completedAt": "2022-10-20T05:11:36.860Z"
 }

--- a/src/backend/controllers/__test__/todo.controller.test.js
+++ b/src/backend/controllers/__test__/todo.controller.test.js
@@ -20,6 +20,21 @@ describe('Todo controller getAllTodos', () => {
   });
 });
 
+describe('Todo controller getAllTodosByUserId', () => {
+  test('getAllTodosByUserId should be a function', () => {
+    expect(typeof todoController.getAllTodosByUserId).toBe('function');
+  });
+  test('getAllTodosByUserId should call Todo model find', async () => {
+    await todoController.getAllTodosByUserId(newTodo.userId);
+    expect(todoModel.find).toHaveBeenCalledWith({ userId: newTodo.userId });
+  });
+  test('getAllTodosByUserId should return a list of todos', async () => {
+    todoModel.find.mockReturnValue(allTodos);
+    const todos = await todoController.getAllTodosByUserId(newTodo.userId);
+    expect(todos).toEqual(allTodos);
+  });
+});
+
 describe('Todo controller createTodo', () => {
   test('createTodo should be a function', () => {
     expect(typeof todoController.createTodo).toBe('function');

--- a/src/backend/controllers/todo.controller.js
+++ b/src/backend/controllers/todo.controller.js
@@ -2,12 +2,15 @@ import TodoModel from '../database/models/todo.model';
 
 const getAllTodos = async () => TodoModel.find();
 
+const getAllTodosByUserId = async (userId) => TodoModel.find({ userId });
+
 const createTodo = async (todo) => TodoModel.create(todo);
 
 const updateTodo = async (id, todo) => TodoModel.updateOne({ _id: id }, todo);
 
 const todoController = {
   getAllTodos,
+  getAllTodosByUserId,
   createTodo,
   updateTodo,
 };

--- a/src/backend/database/models/__test__/todo.model.test.js
+++ b/src/backend/database/models/__test__/todo.model.test.js
@@ -7,6 +7,7 @@ describe('Todo model', () => {
   test('Todo model should have set properties', () => {
     expect(todoModel.schema.obj).toHaveProperty('content');
     expect(todoModel.schema.obj).toHaveProperty('done');
+    expect(todoModel.schema.obj).toHaveProperty('userId');
     expect(todoModel.schema.obj).toHaveProperty('createdAt');
     expect(todoModel.schema.obj).toHaveProperty('completedAt');
   });

--- a/src/backend/database/models/todo.model.js
+++ b/src/backend/database/models/todo.model.js
@@ -11,6 +11,10 @@ const TodoSchema = new Schema({
     type: Boolean,
     default: false,
   },
+  userId: {
+    type: String,
+    required: true,
+  },
   createdAt: { type: Date, required: true },
   completedAt: { type: Date, default: null },
 });

--- a/src/backend/routes/api.js
+++ b/src/backend/routes/api.js
@@ -11,6 +11,9 @@ const routes = {
   '/api/todo/:id': {
     PUT: TodoController.updateTodo,
   },
+  '/api/todo/user/:userId': {
+    GET: TodoController.getAllTodosByUserId,
+  },
 };
 
 export default routes;

--- a/src/backend/routes/constants.js
+++ b/src/backend/routes/constants.js
@@ -1,9 +1,11 @@
 const todoBaseUrl = '/api/todo';
 const todoIdUrl = '/api/todo/:id';
+const todoUserIdUrl = '/api/todo/user/:userId';
 
 const urls = {
   todoBaseUrl,
   todoIdUrl,
+  todoUserIdUrl,
 };
 
 export default urls;

--- a/src/components/pages/TodosPage.module.css
+++ b/src/components/pages/TodosPage.module.css
@@ -38,3 +38,15 @@
 .todoInputContainer {
     padding: 0 1rem;
 }
+
+.loading_container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+.loading_text {
+    font-size: 2rem;
+    font-weight: bold;
+}

--- a/src/pages/api/todo/index.js
+++ b/src/pages/api/todo/index.js
@@ -8,8 +8,9 @@ export default async function handler(req, res) {
   const strategy = route ? route[method] : null;
 
   if (strategy) {
+    const statusCode = method === 'POST' ? 201 : 200;
     const result = await strategy(body);
-    res.status(200).json(result);
+    res.status(statusCode).json(result);
   } else {
     res.status(405).json({ message: 'Method not allowed' });
   }

--- a/src/pages/api/todo/user/[id].js
+++ b/src/pages/api/todo/user/[id].js
@@ -1,0 +1,19 @@
+import routes from '../../../../backend/routes/api';
+import urls from '../../../../backend/routes/constants';
+
+export default async function handler(req, res) {
+  const { method, query } = req;
+  const { id } = query;
+
+  const route = routes[urls.todoUserIdUrl];
+  const strategy = route ? route[method] : null;
+
+  if (strategy) {
+    if (method === 'GET') {
+      const result = await strategy(id);
+      res.status(200).json(result);
+    }
+  } else {
+    res.status(405).json({ message: 'Method not allowed' });
+  }
+}

--- a/src/utils/api/todos.js
+++ b/src/utils/api/todos.js
@@ -11,6 +11,17 @@ export const getTodos = () => {
     });
 };
 
+export const getTodosByUserId = (userId) => {
+  return axios
+    .get(`/api/todo/user/${userId}`)
+    .then((response) => response.data)
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      return [];
+    });
+};
+
 export const addTodo = (todo) => {
   return axios
     .post('/api/todo', todo)
@@ -37,6 +48,7 @@ const todosApi = {
   getTodos,
   addTodo,
   updateTodo,
+  getTodosByUserId,
 };
 
 export default todosApi;

--- a/src/utils/mappers.js
+++ b/src/utils/mappers.js
@@ -1,6 +1,7 @@
-const todoInputMapper = (todoInput) => ({
-  content: todoInput,
+const todoInputMapper = (todoContent, userId) => ({
+  content: todoContent,
   done: false,
+  userId,
   createdAt: new Date().toISOString(),
 });
 
@@ -9,14 +10,16 @@ const todoOutputMapper = (todo) => ({
   id: todo._id,
   content: todo.content,
   done: todo.done,
+  userId: todo.userId,
   createdAt: todo.createdAt,
   completedAt: todo.completedAt,
 });
 
-const todoRebuildMapper = ({ id, content, done, createdAt }) => ({
+const todoRebuildMapper = ({ id, content, done, userId, createdAt }) => ({
   id,
   content,
   done,
+  userId,
   createdAt,
   completedAt: new Date().toISOString(),
 });


### PR DESCRIPTION
This commit:

- Adds default userId field for every todo to keep the reference of which user created which todo
- Updates models and controllers to use userId field
- Adds routes to get todos by userId
- Replaces default route used in the web page for getting todos
- Disables default query loading when trying to load dashboard without a user
- Sets styling for loading page